### PR TITLE
update to Typst 0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Typst 将会创建一个新的目录，其中包含了所有你开始**除字体
 
 ## 更改记录
 
+2025-06-01（PR from [Capt-Lappland](https://github.com/Capt-Lappland)）
+
+- 更新到 Typst 0.13
+- 更新 Typst 包
+    - ctheorems: 1.1.2 ——> 1.1.3
+
 2024-08-20
 
 - 更改附录页代码框样式

--- a/lib.typ
+++ b/lib.typ
@@ -1,4 +1,4 @@
-#import "@preview/ctheorems:1.1.2": *
+#import "@preview/ctheorems:1.1.3": *
 
 // 文本和代码的字体
 #let songti = "SimSun"
@@ -286,7 +286,7 @@
   set page(
     paper: "a4",
     margin: (top: 2.5cm, bottom: 2.5cm, left: 2.5cm, right: 2.5cm),
-    footer: align(center)[#text(counter(page).display("1"), font: songti, size: 12pt)]
+    footer: align(center)[#context(counter(page).display("1"))]
   )
 
   // 摘要
@@ -324,7 +324,7 @@
     fill: (_, row) => if row == 0 or row == 1 {luma(200)} else {none},
     rows: 3,
     columns: 1fr,
-    text[*附录 #appendix-num.display()：*],
+    text[*附录 #context appendix-num.display()：*],
     text[*#title*],
     body
   )


### PR DESCRIPTION
Typest 0.13修改了部分语法，目前在Typst App中本模板无法使用。修改了模板的语法以适配更新。